### PR TITLE
Fixed typographical error, changed anyhwere to anywhere in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 $ mkdir build && cd build && cmake .. && make
 ```
 
-The resulting plugin can be copied anyhwere on the system.
+The resulting plugin can be copied anywhere on the system.
 
 Example usage
 -------------


### PR DESCRIPTION
@jedisct1, I've corrected a typographical error in the documentation of the [dnscrypt-plugin-geoip-block](https://github.com/jedisct1/dnscrypt-plugin-geoip-block) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.